### PR TITLE
4 digit CVC

### DIFF
--- a/lib/formatters/credit_card_cvc_input_formatter.dart
+++ b/lib/formatters/credit_card_cvc_input_formatter.dart
@@ -27,5 +27,5 @@ THE SOFTWARE.
 import 'package:flutter_multi_formatter/formatters/masked_input_formatter.dart';
 
 class CreditCardCvcInputFormatter extends MaskedInputFormater {
-  CreditCardCvcInputFormatter() : super('000');
+  CreditCardCvcInputFormatter() : super('0000');
 }


### PR DESCRIPTION
Simple modification to allow CVC formatter to account for 4 digit CVC codes that occur with AMEX cards.

Closes #8