### PR TITLE
credit card formatter input fix

### DIFF
--- a/lib/formatters/credit_card_number_input_formatter.dart
+++ b/lib/formatters/credit_card_number_input_formatter.dart
@@ -192,15 +192,16 @@ class _CardSystemDatas {
     if (subscringLength < 1) return null;
     var systemCode = cardNumber.substring(0, subscringLength);
 
-    var rawData = _data.firstWhere(
-        (Map<String, dynamic> data) {
-          var numericValue = toNumericString(data['systemCode']);
-          var numDigits = data['numDigits'];
-          return numericValue == systemCode &&
-              numDigits >= cardNumber.length &&
-              numDigits <= _maxDigitsInCard;
-        } as bool Function(Map<String, dynamic>?),
-        orElse: () => null);
+    var rawData = _data.firstWhere((Map<String, dynamic>? data) {
+      if (data != null) {
+        var numericValue = toNumericString(data['systemCode']);
+        var numDigits = data['numDigits'];
+        return numericValue == systemCode &&
+            numDigits >= cardNumber.length &&
+            numDigits <= _maxDigitsInCard;
+      }
+      return false;
+    }, orElse: () => null);
     if (rawData != null) {
       return CardSystemData.fromMap(rawData);
     }


### PR DESCRIPTION
New nullsafety version throws an error trying to cast
bool Function(Map<String, dynamic>)->bool Function(Map<String, dynamic>?)
As result it prevent any input in credit card number text field