### PR TITLE
Fix _lastValue bug in formatEditUpdate

### DIFF
--- a/lib/formatters/phone_input_formatter.dart
+++ b/lib/formatters/phone_input_formatter.dart
@@ -97,6 +97,7 @@ class PhoneInputFormatter extends TextInputFormatter {
     maskedValue = _applyMask(onlyNumbers, allowEndlessPhone);
     // if (maskedValue.length == oldValue.text.length && onlyNumbers != '7') {
     if (maskedValue == oldValue.text && onlyNumbers != '7') {
+      _lastValue = oldValue.text;
       if (isErasing) {
         var newSelection = oldValue.selection;
         newSelection = newSelection.copyWith(


### PR DESCRIPTION
Before: If we type something into a TextField with disabled allowEndlessPhone after a phone number is filled and then try to get its value using PhoneInputFormatter masked on unmasked property we will get incorrect value with an excess digit.
After the fix: all working as expected.