### PR TITLE
Added clearing of mask to avoid inserting of a wrong char

### DIFF
--- a/lib/formatters/masked_input_formatter.dart
+++ b/lib/formatters/masked_input_formatter.dart
@@ -172,18 +172,19 @@ class MaskedInputFormatter extends TextInputFormatter {
   FormattedValue applyMask(String text) {
     _prepareMask();
     String clearedValueAfter = _removeSeparators(text);
+    String clearedMask = _removeSeparators(mask);
     final isErasing = _maskedValue.length > text.length;
     FormattedValue formattedValue = FormattedValue();
     StringBuffer stringBuffer = StringBuffer();
     var index = 0;
     final maxLength = min(
       clearedValueAfter.length,
-      mask.length - _separatorChars.length,
+      clearedMask.length,
     );
 
     for (var i = 0; i < maxLength; i++) {
       final curChar = clearedValueAfter[i];
-      final charInMask = mask[i];
+      final charInMask = clearedMask[i];
       final maskOnDigitMatcher = charInMask == _onlyDigitMask;
       if (maskOnDigitMatcher) {
         if (!isDigit(curChar)) {


### PR DESCRIPTION
Hello! Thank you for great package! 

I've found a small issue regarding to `MaskedInputFormatter`. So, I've tried to use this in the next way: `MaskedInputFormatter('###-00-#####')` and after I wrote `qwe` I pressed `r` and got `qwe-r`, but have to get nothing put - `qwe`, because `0` is only digits. And only if I write `qwe` and then, for example, 2, I have to get `qwe-2`.