### PR TITLE
Updated phoneMasks for Belgium

### DIFF
--- a/lib/formatters/phone_input_formatter.dart
+++ b/lib/formatters/phone_input_formatter.dart
@@ -607,7 +607,7 @@ class PhoneCodes {
       'country': 'Belgium',
       'internalPhoneCode': '32',
       'countryCode': 'BE',
-      'phoneMask': '+00 000 000 0000',
+      'phoneMask': '+00 000 00 00 00',
     },
     {
       'country': 'Belize',


### PR DESCRIPTION
Updated phone masks for Belgium according to the following documents :

- https://en.wikipedia.org/wiki/Telephone_numbers_in_Belgium#Mobile_numbers
- https://fr.wikipedia.org/wiki/Num%C3%A9ro_de_t%C3%A9l%C3%A9phone#B (French only - see the "Format international" line)

Also cross-checked with the formatting used in my phone/Whatsapp