### PR TITLE
Update unfocuser to fix flutter_lints warnings

### DIFF
--- a/lib/utils/unfocuser.dart
+++ b/lib/utils/unfocuser.dart
@@ -110,9 +110,8 @@ class _UnfocuserState extends State<Unfocuser> {
 }
 
 class IgnoreUnfocuser extends SingleChildRenderObjectWidget {
-  final Widget child;
-
-  IgnoreUnfocuser({required this.child}) : super(child: child);
+  const IgnoreUnfocuser({Key? key, required Widget child})
+      : super(key: key, child: child);
 
   @override
   IgnoreUnfocuserRenderBox createRenderObject(BuildContext context) {
@@ -121,9 +120,8 @@ class IgnoreUnfocuser extends SingleChildRenderObjectWidget {
 }
 
 class ForceUnfocuser extends SingleChildRenderObjectWidget {
-  final Widget child;
-
-  ForceUnfocuser({required this.child}) : super(child: child);
+  const ForceUnfocuser({Key? key, required Widget child})
+      : super(key: key, child: child);
 
   @override
   ForceUnfocuserRenderBox createRenderObject(BuildContext context) {


### PR DESCRIPTION
I found your solution to close keyboard automatically when tapping outside.

It works super well! so i implemented it in my project as well.
In my project i set up `flutter_lints` and it was showing some warnings.

Here is the changes i did on my own project, feel free to merge it or not.

Anyway, thank you for your solution.