### PR TITLE
fixing "-" error in maskedInputFormatter

### DIFF
--- a/lib/formatters/formatter_utils.dart
+++ b/lib/formatters/formatter_utils.dart
@@ -98,3 +98,10 @@ bool isDigit(String? character) {
   }
   return _digitRegExp.stringMatch(character) != null;
 }
+
+bool isPositiveDigit(String? character) {
+  if (character == null || character.isEmpty || character.length > 1) {
+    return false;
+  }
+  return _positiveDigitRegExp.stringMatch(character) != null;
+}

--- a/lib/formatters/masked_input_formatter.dart
+++ b/lib/formatters/masked_input_formatter.dart
@@ -44,6 +44,7 @@ class MaskedInputFormatter extends TextInputFormatter {
   final String _anyCharMask = '#';
   final String _onlyDigitMask = '0';
   final RegExp? allowedCharMatcher;
+  final bool? allowOnlyPositiveNumbers;
   final List<_Separator> _separators = [];
 
   // List<int> _separatorIndices = <int>[];
@@ -66,6 +67,7 @@ class MaskedInputFormatter extends TextInputFormatter {
   MaskedInputFormatter(
     this.mask, {
     this.allowedCharMatcher,
+    this.allowOnlyPositiveNumbers,
   });
 
   bool get isFilled => _maskedValue.length == mask.length;
@@ -200,8 +202,14 @@ class MaskedInputFormatter extends TextInputFormatter {
           final maskOnDigitMatcher = splitMask[i] == _onlyDigitMask;
           var curChar = clearedValueAfter[index];
           if (maskOnDigitMatcher) {
-            if (!isDigit(curChar)) {
-              break;
+            if(allowOnlyPositiveNumbers != true){
+              if (!isDigit(curChar)) {
+                break;
+            }
+            }else{
+               if (!isPositiveDigit(curChar)) {
+                break;
+            }
             }
           } else {
             if (!_isMatchingRestrictor(curChar)) {


### PR DESCRIPTION
In the current version, this code is not working correctly:

return [MaskedInputFormatter('00/00/0000', allowedCharMatcher: RegExp(r'[0-9]')];

Im able to write: "07/07/2--2, because the regex used by "isDigit" allows "-".

Now, in this pull request, the user is able to do this: 

return [MaskedInputFormatter('00/00/0000', allowedCharMatcher: RegExp(r'[0-9]'), allowOnlyPositiveNumbers: true)];

Then, im not allow to write "-" in my masks anymore.

