### PR TITLE
fixed caretOffset not changing to currency value when deleting with mantissa length being 0

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -96,7 +96,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.0"
+    version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/formatters/currency_input_formatter.dart
+++ b/lib/formatters/currency_input_formatter.dart
@@ -80,9 +80,9 @@ class CurrencyInputFormatter extends TextInputFormatter {
     this.onValueChange,
     this.maxTextLength,
   }) : assert(
-            !leadingSymbol.contains(_illegalLeadingOrTrailing) &&
-                !trailingSymbol.contains(_illegalLeadingOrTrailing),
-            '''
+  !leadingSymbol.contains(_illegalLeadingOrTrailing) &&
+      !trailingSymbol.contains(_illegalLeadingOrTrailing),
+  '''
     Illegal trailing or reading symbol. You cannot use 
     the next symbols as leading or trailing because 
     they might interfere with numbers: -,.+
@@ -98,9 +98,9 @@ class CurrencyInputFormatter extends TextInputFormatter {
 
   @override
   TextEditingValue formatEditUpdate(
-    TextEditingValue oldValue,
-    TextEditingValue newValue,
-  ) {
+      TextEditingValue oldValue,
+      TextEditingValue newValue,
+      ) {
     final trailingLength = _getTrailingLength();
     final leadingLength = _getLeadingLength();
     final oldCaretIndex = max(oldValue.selection.start, oldValue.selection.end);
@@ -120,6 +120,11 @@ class CurrencyInputFormatter extends TextInputFormatter {
     }
     bool isErasing = newText.length < oldText.length;
     if (isErasing) {
+      if(mantissaLength == 0 && oldCaretIndex == oldValue.text.length) {
+        return oldValue.copyWith(
+            selection: TextSelection.collapsed(offset: oldCaretIndex - trailingLength)
+        );
+      }
       if (_hasErasedMantissaSeparator(
         shorterString: newText,
         longerString: oldText,
@@ -336,7 +341,7 @@ class CurrencyInputFormatter extends TextInputFormatter {
     required int oldCaretOffset,
   }) {
     if (mantissaLength < 1) {
-      return oldCaretOffset - trailingSymbol.length;
+      return 0;
     }
     final mantissaIndex = oldText.lastIndexOf(
       _mantissaSeparatorRegexp,

--- a/lib/formatters/currency_input_formatter.dart
+++ b/lib/formatters/currency_input_formatter.dart
@@ -336,7 +336,7 @@ class CurrencyInputFormatter extends TextInputFormatter {
     required int oldCaretOffset,
   }) {
     if (mantissaLength < 1) {
-      return 0;
+      return oldCaretOffset - trailingSymbol.length;
     }
     final mantissaIndex = oldText.lastIndexOf(
       _mantissaSeparatorRegexp,


### PR DESCRIPTION
Hello, @caseyryan 👋🏽

Thank you for your awesome package!

Recently i have encountered several problems with currency formatter, one of which you have already fixed. But there is another problem related to mantissa length being 0: If caret is set to the trailing symbol or after it, user is unable to delete from input field. However this works normal if mantissa length is above 0, on delete, caret is displaced before the trailing symbol and then value deletion is happening. But with mantissa length being 0 caret is simply stuck on trailing symbol. I have provided two videos with before and after the fix:


Before:
https://user-images.githubusercontent.com/56795876/186384007-f6d9f83a-e7a4-4525-a7be-1ddb6d7a4888.mp4

After:
https://user-images.githubusercontent.com/56795876/186384028-a934344f-6154-43c1-b0ac-bf28b100d1c0.mp4

.