### PR TITLE
fix: use proper format for congo phone numbers

### DIFF
--- a/lib/formatters/phone_input_formatter.dart
+++ b/lib/formatters/phone_input_formatter.dart
@@ -2171,7 +2171,7 @@ class PhoneCodes {
       'countryRU': 'Конго, Демократическая Республика',
       'internalPhoneCode': '243',
       'countryCode': 'CD',
-      'phoneMask': '+000 00 000 0000',
+      'phoneMask': '+000 00 00 00000',
     },
     {
       'country': 'Cote d\'Ivoire',

--- a/lib/formatters/phone_input_formatter.dart
+++ b/lib/formatters/phone_input_formatter.dart
@@ -1053,7 +1053,7 @@ class PhoneCodes {
       'countryRU': 'Конго',
       'internalPhoneCode': '242',
       'countryCode': 'CG',
-      'phoneMask': '+000 00 000 0000',
+      'phoneMask': '+000 00 00 00000',
     },
     {
       'country': 'Cook Islands',

--- a/test/flutter_multi_formatter_test.dart
+++ b/test/flutter_multi_formatter_test.dart
@@ -85,4 +85,45 @@ void main() {
     );
     expect(withoutDefault, formatted);
   });
+
+  group('congo', () {
+    test('should format partial congo mask +000 00', () {
+      final inputNumber = '+24255';
+
+      final formattedNumber = PhoneInputFormatter()
+          .formatEditUpdate(
+            TextEditingValue(text: ''),
+            TextEditingValue(text: inputNumber),
+          )
+          .text;
+
+      expect(formattedNumber, '+242 55');
+    });
+
+    test('should format partial congo mask +000 00 00', () {
+      final inputNumber = '+2425566';
+
+      final formattedNumber = PhoneInputFormatter()
+          .formatEditUpdate(
+            TextEditingValue(text: ''),
+            TextEditingValue(text: inputNumber),
+          )
+          .text;
+
+      expect(formattedNumber, '+242 55 66');
+    });
+
+    test('should format full congo mask +000 00 00 00000', () {
+      final inputNumber = '+242556677777';
+
+      final formattedNumber = PhoneInputFormatter()
+          .formatEditUpdate(
+            TextEditingValue(text: ''),
+            TextEditingValue(text: inputNumber),
+          )
+          .text;
+
+      expect(formattedNumber, '+242 55 66 77777');
+    });
+  });
 }

--- a/test/flutter_multi_formatter_test.dart
+++ b/test/flutter_multi_formatter_test.dart
@@ -87,43 +87,86 @@ void main() {
   });
 
   group('congo', () {
-    test('should format partial congo mask +000 00', () {
-      final inputNumber = '+24255';
+    group('242', () {
+      test('should format partial congo mask +000 00', () {
+        final inputNumber = '+24255';
 
-      final formattedNumber = PhoneInputFormatter()
-          .formatEditUpdate(
-            TextEditingValue(text: ''),
-            TextEditingValue(text: inputNumber),
-          )
-          .text;
+        final formattedNumber = PhoneInputFormatter()
+            .formatEditUpdate(
+              TextEditingValue(text: ''),
+              TextEditingValue(text: inputNumber),
+            )
+            .text;
 
-      expect(formattedNumber, '+242 55');
+        expect(formattedNumber, '+242 55');
+      });
+
+      test('should format partial congo mask +000 00 00', () {
+        final inputNumber = '+2425566';
+
+        final formattedNumber = PhoneInputFormatter()
+            .formatEditUpdate(
+              TextEditingValue(text: ''),
+              TextEditingValue(text: inputNumber),
+            )
+            .text;
+
+        expect(formattedNumber, '+242 55 66');
+      });
+
+      test('should format full congo mask +000 00 00 00000', () {
+        final inputNumber = '+242556677777';
+
+        final formattedNumber = PhoneInputFormatter()
+            .formatEditUpdate(
+              TextEditingValue(text: ''),
+              TextEditingValue(text: inputNumber),
+            )
+            .text;
+
+        expect(formattedNumber, '+242 55 66 77777');
+      });
     });
 
-    test('should format partial congo mask +000 00 00', () {
-      final inputNumber = '+2425566';
+    group('243', () {
+      test('should format partial congo mask +000 00', () {
+        final inputNumber = '+24355';
 
-      final formattedNumber = PhoneInputFormatter()
-          .formatEditUpdate(
-            TextEditingValue(text: ''),
-            TextEditingValue(text: inputNumber),
-          )
-          .text;
+        final formattedNumber = PhoneInputFormatter()
+            .formatEditUpdate(
+              TextEditingValue(text: ''),
+              TextEditingValue(text: inputNumber),
+            )
+            .text;
 
-      expect(formattedNumber, '+242 55 66');
-    });
+        expect(formattedNumber, '+243 55');
+      });
 
-    test('should format full congo mask +000 00 00 00000', () {
-      final inputNumber = '+242556677777';
+      test('should format partial congo mask +000 00 00', () {
+        final inputNumber = '+2435566';
 
-      final formattedNumber = PhoneInputFormatter()
-          .formatEditUpdate(
-            TextEditingValue(text: ''),
-            TextEditingValue(text: inputNumber),
-          )
-          .text;
+        final formattedNumber = PhoneInputFormatter()
+            .formatEditUpdate(
+              TextEditingValue(text: ''),
+              TextEditingValue(text: inputNumber),
+            )
+            .text;
 
-      expect(formattedNumber, '+242 55 66 77777');
+        expect(formattedNumber, '+243 55 66');
+      });
+
+      test('should format full congo mask +000 00 00 00000', () {
+        final inputNumber = '+243556677777';
+
+        final formattedNumber = PhoneInputFormatter()
+            .formatEditUpdate(
+              TextEditingValue(text: ''),
+              TextEditingValue(text: inputNumber),
+            )
+            .text;
+
+        expect(formattedNumber, '+243 55 66 77777');
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes or additions you have made in this pull request. -->

What an awesome package you've put together! I started using this in a project, and came across an incorrect formatting for phone numbers in the Republic of Congo.

## Motivation and Context

<!-- Explain the motivation behind your changes and provide any relevant context. Why is this change necessary? -->

In order to provide the correct format for a phone input for the Republic of Congo, I had to update the mask in `lib/formatters/phone_input_formatter.dart`. The proper mask should be `+000 00 00 00000`. [Reference](https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Republic_of_the_Congo#:~:text=To%20call%20in%20the%20Republic,outside%20Republic%20of%20the%20Congo)

## Changes Made

<!-- Describe the specific changes or additions you have made in this pull request. List the files or code snippets that have been modified. -->

Updated the mask to use the proper format.

## How to Test

<!-- Provide clear instructions on how to test the changes you have made. Include any relevant setup or configuration steps. -->

You can use the international code `+242` to start formatting a Congo number.

## Checklist

- [X] I have followed the project's coding style guidelines.
- [X] I have performed a self-review of my code.
- [X] I have written unit tests or provided a rationale for why tests are not necessary.
- [X] I have updated the project documentation if necessary.
- [X] I have added necessary comments and documentation within the code.
- [X] I have tested my changes locally and they work as expected.

## Additional Notes

<!-- Add any additional notes or information that may be helpful for the reviewers. -->

You currently have two failing tests around the formatting of numbers in the Philippines. I didn't want to touch those in this PR though due to separation of concerns, but wanted to mention it.