### PR TITLE
Allows get data in PhoneCodes bypassing caching

### DIFF
--- a/lib/formatters/phone_input_formatter.dart
+++ b/lib/formatters/phone_input_formatter.dart
@@ -692,8 +692,10 @@ class PhoneCodes {
 
   /// [returns] a list of all available country codes like
   /// ['RU', 'US', 'GB'] etc
-  static List<String> getAllCountryCodes() {
-    if (_countryCodes == null) {
+  static List<String> getAllCountryCodes({
+    bool isForce = false,
+  }) {
+    if (_countryCodes == null || isForce) {
       _countryCodes = _data.map((e) => e['countryCode'].toString()).toList();
     }
     return _countryCodes!;
@@ -708,8 +710,9 @@ class PhoneCodes {
   /// Just keep the naming convention like countryBR, countryDE and so on
   static List<PhoneCountryData> getAllCountryDatas({
     String langCode = '',
+    bool isForce = false,
   }) {
-    if (_allCountryDatas == null) {
+    if (_allCountryDatas == null || isForce) {
       _allCountryDatas = _data
           .map((e) => e.containsKey('country${langCode.toUpperCase()}')
               ? PhoneCountryData.fromMap(e, lang: langCode)


### PR DESCRIPTION
I was getting country datas from PhoneCodes for the profile/settings page. On the same page it was possible to switch locale from English to Russian and vice versa. But because of _allCountryDatas I couldn't get an updated list of countries.
I rebuild the page using Bloc, but any other ways didn't work either. Only if I completely reload the page, which is not suitable. 
So I added the isForce argument to bypass unnecessary caching, but I don't really see the point of _countryCodes and _allCountryDatas anyway.