### PR TITLE
Replace mask should work regardless of `kDebugMode`

### DIFF
--- a/lib/formatters/phone_input_formatter.dart
+++ b/lib/formatters/phone_input_formatter.dart
@@ -240,13 +240,19 @@ class PhoneInputFormatter extends TextInputFormatter {
     checkMask(newMask);
     final countryData = _findCountryDataByCountryCode(countryCode);
     var currentMask = countryData['phoneMask'];
-    if (currentMask != newMask && kDebugMode) {
+
+    if (currentMask == newMask) {
+      return;
+    }
+
+    if (kDebugMode) {
       print(
         'Phone mask for country "${countryData['country']}"' +
             ' was replaced from $currentMask to $newMask',
       );
-      countryData['phoneMask'] = newMask;
     }
+
+    countryData['phoneMask'] = newMask;
   }
 
   static Map<String, dynamic> _findCountryDataByCountryCode(


### PR DESCRIPTION
Hi, thank you for wonderful package. 

The `replacePhoneMask` method currently does not apply the mask because of the condition which only runs when `kDebugMode` is `true`. This PR fixes that behaviour.