### PR TITLE
Added new mask for Germany

### DIFF
--- a/lib/formatters/phone_input_formatter.dart
+++ b/lib/formatters/phone_input_formatter.dart
@@ -1275,7 +1275,10 @@ class PhoneCodes {
       'countryRU': 'Германия',
       'internalPhoneCode': '49',
       'countryCode': 'DE',
-      'phoneMask': '+00 00 000000000',
+      'phoneMask': '+00 00 00000000',
+      'altMasks': [
+        '+00 00 000000000',
+      ]
     },
     {
       'country': 'Ghana',


### PR DESCRIPTION
In Germany, there are phone numbers with a length of 10. Information from these sources:
https://en.wikipedia.org/wiki/Telephone_numbers_in_Germany
https://callhippo.com/blog/general/germany-phone-number-example