### PR TITLE
Fix decimal separator issue for countries using "," as decimal separator

### DIFF
--- a/lib/formatters/currency_input_formatter.dart
+++ b/lib/formatters/currency_input_formatter.dart
@@ -397,7 +397,8 @@ class CurrencyInputFormatter extends TextInputFormatter {
       /// [hasWrongSeparator] is an attempt to fix this
       /// https://github.com/caseyryan/flutter_multi_formatter/issues/114
       /// Not sure if it will have some side effect
-      final hasWrongSeparator = newText.contains(',.');
+      final hasWrongSeparator =
+          newText.contains(',.') || newText.contains('.,');
       if (_containsMantissaSeparator(newChars) || hasWrongSeparator) {
         return true;
       }


### PR DESCRIPTION
correction for: https://github.com/caseyryan/flutter_multi_formatter/issues/154

In countries where "," is used as a decimal separator, users commonly input both "," and "." to represent decimals. This commit adjusts the logic to detect both ",." and ".,", ensuring correct handling of decimal separators, particularly in regions where "." is used as a thousand separator

