### PR TITLE
Change brazilian masks priorities 

### DIFF
--- a/lib/formatters/phone_input_formatter.dart
+++ b/lib/formatters/phone_input_formatter.dart
@@ -952,9 +952,9 @@ class PhoneCodes {
       'countryRU': 'Бразилия',
       'internalPhoneCode': '55',
       'countryCode': 'BR',
-      'phoneMask': '+00 (00) 0000-0000',
+      'phoneMask': '+00 (00) 00000-0000',
       'altMasks': [
-        '+00 (00) 00000-0000',
+        '+00 (00) 0000-0000',
       ],
     },
     {


### PR DESCRIPTION
### The most common use case for phone numbers in Brazil is the 9 digits format.

---

Translated with DeepL.com (free version) from [https://www.gov.br/anatel/pt-br/regulado/numeracao/plano-de-numeracao-brasileiro](https://www.gov.br/anatel/pt-br/regulado/numeracao/plano-de-numeracao-brasileiro)

### Brazilian numbering plan

*Published on 03/03/2015 19h04 Updated on 13/04/2022 18h11*

The Numbering Plan adopted in Brazil follows the recommendations of the International Telecommunication Union - ITU, in particular Recommendation E.164.

As a result, the numbering follows the pattern:

```COUNTRY_CODE AREA_CODE SUBSCRIBER_NUMBER ```

The ITU has defined the Country Code for Brazil in the format [55].

The Area Code has the two-digit format [xx].

The subscriber number has the format:

- Eight digits [abcd-mcdu], in the case of the Fixed Switched Telephone Service (fixed telephony).
- Nine digits [abcde-mcdu], for the Personal Mobile Service (cellular mobile telephony).
- Eight digits [abcd-mcdu], for the Specialized Mobile Service (radio mobile telephony).

---

**The last items are the important here: nine digits numbers is what the majority people uses.**
