### PR TITLE
Inconsistence between value and text

### DIFF
--- a/lib/formatters/currency_input_formatter.dart
+++ b/lib/formatters/currency_input_formatter.dart
@@ -172,13 +172,7 @@ class CurrencyInputFormatter extends TextInputFormatter {
     int oldCaretIndex = max(oldValue.selection.start, oldValue.selection.end);
     int newCaretIndex = max(newValue.selection.start, newValue.selection.end);
     var newText = newValue.text;
-    final newAsNumeric = toNumericString(
-      newText,
-      allowPeriod: true,
-      mantissaSeparator: _mantissaSeparator,
-      mantissaLength: mantissaLength,
-    );
-    _updateValue(newAsNumeric);
+    final newAsNumeric = _updateValueFromText(newText);
 
     var oldText = oldValue.text;
     if (oldValue == newValue) {
@@ -231,6 +225,10 @@ class CurrencyInputFormatter extends TextInputFormatter {
         if (_printDebugInfo) {
           print('RETURN 2 ${oldValue.text}');
         }
+
+        // propagate previous correct value with mantissa separator
+        _updateValueFromText(oldText);
+
         return oldValue.copyWith(
           selection: TextSelection.collapsed(
             offset: min(
@@ -245,6 +243,10 @@ class CurrencyInputFormatter extends TextInputFormatter {
         if (_printDebugInfo) {
           print('RETURN 3 ${oldValue.text}');
         }
+
+        // propagate previous correct value without illegal chars
+        _updateValueFromText(oldText);
+
         return oldValue;
       }
     }
@@ -270,6 +272,10 @@ class CurrencyInputFormatter extends TextInputFormatter {
       if (_printDebugInfo) {
         print('RETURN 4 ${oldValue.text.length} $oldCaretIndex');
       }
+
+      // propagate previous correct value with correct mantissa position
+      _updateValueFromText(oldText);
+
       return oldValue.copyWith(
         selection: TextSelection.collapsed(
           offset: min(
@@ -299,6 +305,7 @@ class CurrencyInputFormatter extends TextInputFormatter {
         if (_printDebugInfo) {
           print('RETURN 6 $newAsCurrency');
         }
+
         int offset = min(
           newCaretIndex,
           newAsCurrency.length - trailingLength,
@@ -355,6 +362,7 @@ class CurrencyInputFormatter extends TextInputFormatter {
     if (_printDebugInfo) {
       print('RETURN 8 $newAsCurrency');
     }
+
     return TextEditingValue(
       selection: TextSelection.collapsed(
         offset: initialCaretOffset,

--- a/lib/formatters/currency_input_formatter.dart
+++ b/lib/formatters/currency_input_formatter.dart
@@ -110,7 +110,6 @@ class CurrencyInputFormatter extends TextInputFormatter {
   /// be used.
   ///
   /// @{endtemplate}
-  ///
   void _updateValue(String value) {
     if (onValueChange == null) {
       return;
@@ -162,6 +161,23 @@ class CurrencyInputFormatter extends TextInputFormatter {
     return '.';
   }
 
+  // For the package developers: if you added a new return case here and it's return
+  // a value that does not match the value triggered on "onChangedValue" then you
+  // need to call [_updateValue] or [_updateValueFromText] method before returning
+  // the value.
+  //
+  // Take as example the "RETURN 3" case:
+  //
+  // ```dart
+  // // ...
+  // if (_printDebugInfo) {
+  //   print('RETURN 3 ${oldValue.text}');
+  // }
+  //
+  // _updateValueFromText(oldText); // <-- this is the line that needs to be added
+  //
+  // return oldValue;
+  // ```
   @override
   TextEditingValue formatEditUpdate(
     TextEditingValue oldValue,

--- a/lib/formatters/currency_input_formatter.dart
+++ b/lib/formatters/currency_input_formatter.dart
@@ -523,10 +523,11 @@ class CurrencyInputFormatter extends TextInputFormatter {
       if (sub.length > leadingSymbol.length) {
         return true;
       }
-      clearedInput = clearedInput.replaceAll(RegExp('[$leadingSymbol]+'), '');
+
+      clearedInput = clearedInput.replaceFirst(leadingSymbol, '');
     }
     if (trailingSymbol.isNotEmpty) {
-      clearedInput = clearedInput.replaceAll(RegExp('[$trailingSymbol]+'), '');
+      clearedInput = clearedInput.replaceFirst(trailingSymbol, '');
     }
     clearedInput = clearedInput.replaceAll(' ', '');
     return _illegalCharsRegexp.hasMatch(clearedInput);

--- a/lib/formatters/currency_input_formatter.dart
+++ b/lib/formatters/currency_input_formatter.dart
@@ -55,7 +55,7 @@ class CurrencyInputFormatter extends TextInputFormatter {
   final int? maxTextLength;
   final ValueChanged<num>? onValueChange;
 
-  bool _printDebugInfo = true;
+  bool _printDebugInfo = false;
 
   /// Indicates if there are any scheduled updates using [_widgetsBinding]'s `addPostFrameCallback`.
   bool _scheduledUpdate = false;
@@ -464,8 +464,7 @@ class CurrencyInputFormatter extends TextInputFormatter {
       /// [hasWrongSeparator] is an attempt to fix this
       /// https://github.com/caseyryan/flutter_multi_formatter/issues/114
       /// Not sure if it will have some side effect
-      final hasWrongSeparator =
-          newText.contains(',.') || newText.contains('.,');
+      final hasWrongSeparator = newText.contains(',.') || newText.contains('.,');
       if (_containsMantissaSeparator(newChars) || hasWrongSeparator) {
         return true;
       }
@@ -483,8 +482,7 @@ class CurrencyInputFormatter extends TextInputFormatter {
         var nextChar = '';
         if (caretPosition < newText.length - 1) {
           nextChar = newText[caretPosition];
-          if (!isDigit(nextChar, positiveOnly: true) ||
-              int.tryParse(nextChar) == 0) {
+          if (!isDigit(nextChar, positiveOnly: true) || int.tryParse(nextChar) == 0) {
             return true;
           }
         }


### PR DESCRIPTION
## Solve bugs with inconsistent `onValueChange` callback value

In order to solve the [Multiplied by 100](#159) bug I've tested the input and compared the value notified by `onValueChange` callback extensively while updated the class. The results are that at least 3 bugs were solved:

#### By fixing `onValueChanged` logic

- [x] https://github.com/caseyryan/flutter_multi_formatter/issues/160
- [x] https://github.com/caseyryan/flutter_multi_formatter/issues/159
- [x] The value is multiplied by 100 when an illegal character is palced before the mantissa
- [x] The mantissa position is different in value and text field
- [x] `onValueChanged` called twice on some cases

#### Other problem with illegal chars

- The value is multiplied by 100 when an illegal character is placed before mantissa AND this character is contained in leading or trailing symbol
  e.g.: typing `"$"` when using `DOLLAR_SIGN` as leading symbol or typing `"d"` when using `"dolars"` as trailing symbol