### PR TITLE
Enhance widget customization

### DIFF
--- a/lib/widgets/country_dropdown.dart
+++ b/lib/widgets/country_dropdown.dart
@@ -32,6 +32,10 @@ class CountryDropdown extends StatefulWidget {
   final bool? enableFeedback;
   final AlignmentGeometry alignment;
   final bool triggerOnCountrySelectedInitially;
+  final EdgeInsetsGeometry? padding;
+  final Widget? disabledHint;
+  final BorderRadius? borderRadius;
+  final Widget? hint;
 
   /// [filter] if you need a predefined list of countries only,
   /// pass it here
@@ -72,6 +76,10 @@ class CountryDropdown extends StatefulWidget {
     this.autovalidateMode,
     this.menuMaxHeight,
     this.enableFeedback,
+    this.hint,
+    this.padding,
+    this.disabledHint,
+    this.borderRadius,
     this.alignment = AlignmentDirectional.centerStart,
   }) : super(key: key);
 
@@ -194,6 +202,10 @@ class _CountryDropdownState extends State<CountryDropdown> {
       enableFeedback: widget.enableFeedback,
       icon: widget.icon,
       isExpanded: true,
+      hint: widget.hint,
+      padding: widget.padding,
+      disabledHint: widget.disabledHint,
+      borderRadius: widget.borderRadius,
       elevation: widget.elevation,
       itemHeight: widget.itemHeight,
       selectedItemBuilder: (c) {

--- a/lib/widgets/country_dropdown.dart
+++ b/lib/widgets/country_dropdown.dart
@@ -9,6 +9,7 @@ class CountryDropdown extends StatefulWidget {
   final CountryItemBuilder? selectedItemBuilder;
   final CountryItemBuilder? listItemBuilder;
   final bool printCountryName;
+  final bool showCountryFlag;
   final PhoneCountryData? initialCountryData;
   final List<PhoneCountryData>? filter;
   final ValueChanged<PhoneCountryData> onCountrySelected;
@@ -50,6 +51,7 @@ class CountryDropdown extends StatefulWidget {
     this.selectedItemBuilder,
     this.listItemBuilder,
     this.printCountryName = false,
+    this.showCountryFlag = true,
     this.initialCountryData,
     this.triggerOnCountrySelectedInitially = true,
     this.filter,
@@ -85,8 +87,7 @@ class _CountryDropdownState extends State<CountryDropdown> {
   void initState() {
     _countryItems = widget.filter ?? PhoneCodes.getAllCountryDatas();
     if (widget.initialCountryData != null) {
-      _initialValue = _countryItems
-              .firstWhereOrNull((c) => c == widget.initialCountryData) ??
+      _initialValue = _countryItems.firstWhereOrNull((c) => c == widget.initialCountryData) ??
           _countryItems.first;
     }
     if (widget.triggerOnCountrySelectedInitially && _initialValue != null) {
@@ -111,12 +112,13 @@ class _CountryDropdownState extends State<CountryDropdown> {
     }
     return Row(
       children: [
-        Padding(
-          padding: const EdgeInsets.only(right: 8.0),
-          child: CountryFlag(
-            countryId: phoneCountryData.countryCode!,
+        if (widget.showCountryFlag)
+          Padding(
+            padding: const EdgeInsets.only(right: 8.0),
+            child: CountryFlag(
+              countryId: phoneCountryData.countryCode!,
+            ),
           ),
-        ),
         Flexible(
           child: Text(
             '+${phoneCountryData.phoneCode}',
@@ -139,12 +141,13 @@ class _CountryDropdownState extends State<CountryDropdown> {
       children: [
         Row(
           children: [
-            Padding(
-              padding: const EdgeInsets.only(right: 8.0),
-              child: CountryFlag(
-                countryId: phoneCountryData.countryCode!,
+            if (widget.showCountryFlag)
+              Padding(
+                padding: const EdgeInsets.only(right: 8.0),
+                child: CountryFlag(
+                  countryId: phoneCountryData.countryCode!,
+                ),
               ),
-            ),
             Text('+${phoneCountryData.phoneCode}'),
           ],
         ),

--- a/lib/widgets/country_dropdown.dart
+++ b/lib/widgets/country_dropdown.dart
@@ -12,7 +12,7 @@ class CountryDropdown extends StatefulWidget {
   final bool showCountryFlag;
   final PhoneCountryData? initialCountryData;
   final List<PhoneCountryData>? filter;
-  final ValueChanged<PhoneCountryData> onCountrySelected;
+  final ValueChanged<PhoneCountryData>? onCountrySelected;
 
   final int elevation;
   final TextStyle? style;
@@ -90,10 +90,12 @@ class _CountryDropdownState extends State<CountryDropdown> {
       _initialValue = _countryItems.firstWhereOrNull((c) => c == widget.initialCountryData) ??
           _countryItems.first;
     }
-    if (widget.triggerOnCountrySelectedInitially && _initialValue != null) {
+    if (widget.triggerOnCountrySelectedInitially &&
+        _initialValue != null &&
+        widget.onCountrySelected != null) {
       _widgetsBinding.addPostFrameCallback((timeStamp) {
         if (_initialValue != null) {
-          widget.onCountrySelected(_initialValue!);
+          widget.onCountrySelected!(_initialValue!);
         }
       });
     }
@@ -171,6 +173,8 @@ class _CountryDropdownState extends State<CountryDropdown> {
 
   @override
   Widget build(BuildContext context) {
+    final enabled = widget.onCountrySelected != null;
+
     return DropdownButtonFormField<PhoneCountryData>(
       key: Key('countryDropdown'),
       isDense: true,
@@ -210,11 +214,13 @@ class _CountryDropdownState extends State<CountryDropdown> {
             ),
           )
           .toList(),
-      onChanged: (PhoneCountryData? data) {
-        if (data != null) {
-          widget.onCountrySelected(data);
-        }
-      },
+      onChanged: enabled
+          ? (PhoneCountryData? data) {
+              if (data != null) {
+                widget.onCountrySelected!(data);
+              }
+            }
+          : null,
       value: _initialValue,
     );
   }


### PR DESCRIPTION
Increase customization of the Country Code Dropdown Form Field:

Fixes [my own issue/suggestion](https://github.com/caseyryan/flutter_multi_formatter/issues/161)

- New short-hand property to show or hide the flag icon on both dropdown value and list (inspired on #156)
- Added some dropdown field style properties to enhance customization
- Turn `onCountrySelected` property nullable, allowing the input to be disabled. 
    Usage:
    
    ```
    CountryDropdown(
      onCountrySelected: null, // Dropdown button disabled
      initialCountryData: PhoneCodes.getPhoneCountryDataByCountryCode(
        'RU',
      ),
    )
    ```

---

### Disabled    

[Screencast from 2024-07-17 23-40-54.webm](https://github.com/user-attachments/assets/e0d0a6d2-6e59-4596-b3cc-dffbef6ebca7)

### Show flag

[Screencast from 2024-07-17 23-42-49.webm](https://github.com/user-attachments/assets/c10e7d69-7600-494a-ada0-7839c3c17c7b)
