### PR TITLE
Update phone mask format for Algeria

### DIFF
--- a/lib/formatters/phone_input_formatter.dart
+++ b/lib/formatters/phone_input_formatter.dart
@@ -780,7 +780,7 @@ class PhoneCodes {
       'countryRU': 'Алжир',
       'internalPhoneCode': '213',
       'countryCode': 'DZ',
-      'phoneMask': '+000 0 000 0000',
+      'phoneMask': '+000 0 00 00 00 00',
     },
     {
       'country': 'American Samoa',


### PR DESCRIPTION
Users can now enter 9-digit phone numbers when using country code +213 (Algeria)